### PR TITLE
Fixing CLASS initialization to use w0 from input parameters.

### DIFF
--- a/hmf_emulator/hmf_emulator.py
+++ b/hmf_emulator/hmf_emulator.py
@@ -230,7 +230,7 @@ class hmf_emulator(Aemulator):
             'wa_fld':       0.0,
             'omega_b':      params['omega_b'],
             'omega_cdm':    params['omega_cdm'],
-            'Omega_Lambda': 1 - self.Omega_m,
+            'Omega_Lambda': 0.0,
             'N_eff':        params['N_eff'],
             'P_k_max_1/Mpc': 10.,
             'z_max_pk':      5.03


### PR DESCRIPTION
Setting Omega_Lambda to 0 so that CLASS will use w0 parsed from input parameters, instead of overwriting it with w0=-1 as it was doing before.